### PR TITLE
Fix Pokémon name to emote conversion

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -27,7 +27,7 @@ export function copyCurrentDay(day, names) {
   }
 
   text = text.replace(/(?<!Zygarde-)1/g, '🟩');
-  text = text.replace(/(?<!Porygon-)2/g, '🔼');
+  text = text.replace(/(?<!Porygon)2/g, '🔼');
   text = text.replace(/3/g, '🔽');
   text = text.replace(/4/g, '🟨');
   text = text.replace(/(?<!Zygarde-)5/g, '🟥');

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -26,11 +26,11 @@ export function copyCurrentDay(day, names) {
     text = text + "\n" + mosaic + (names ? getPokemonFromId(guess.name) : "")
   }
 
-  text = text.replace(/1/g, '🟩');
-  text = text.replace(/2/g, '🔼');
+  text = text.replace(/(?<!Zygarde-)1/g, '🟩');
+  text = text.replace(/(?<!Porygon-)2/g, '🔼');
   text = text.replace(/3/g, '🔽');
   text = text.replace(/4/g, '🟨');
-  text = text.replace(/5/g, '🟥');
+  text = text.replace(/(?<!Zygarde-)5/g, '🟥');
   text = text.replace(/6/g, '🟦');
 
 


### PR DESCRIPTION
Fix issue where Pokémon (form) names are incorrectly converted to emotes.
I saw it with Zygarde forms, so I added lookbehinds for both Zygarde forms and Porygon2. I couldn't think of anything else but there might be more.
![image](https://user-images.githubusercontent.com/35176230/166068991-8949a57c-d7f8-4e0e-aa8a-44520922b6d7.png)
