### PR TITLE
Fix day used to select the secret pokémon in the daily game

### DIFF
--- a/daily.html
+++ b/daily.html
@@ -94,7 +94,7 @@
 
 <br>Issues? Clear your cache!
 <script type="module">
-  import {getCookie} from "./scripts/utils.js";
+  import {getCookie, getLocalDateDay} from "./scripts/utils.js";
   import {setLanguage} from "./scripts/i18n.js";
   import {handleGuess, toggleHints, copyCurrentDay} from "./scripts/game.js";
 
@@ -104,7 +104,8 @@
     $.getJSON("data/pokedex.json", function (data1) {
       pokedex = data1
       $.getJSON("data/daily.json", function (data2) {
-        let date = new Date().toISOString().split("T")[0]
+        let date = getLocalDateDay()
+
         day = parseInt(data2[date][0])
         window.dailypoke = data2[date][1]
         let lang = getCookie('lang', false)

--- a/daily.html
+++ b/daily.html
@@ -104,10 +104,9 @@
     $.getJSON("data/pokedex.json", function (data1) {
       pokedex = data1
       $.getJSON("data/daily.json", function (data2) {
-        let date = getLocalDateDay()
-
-        day = parseInt(data2[date][0])
-        window.dailypoke = data2[date][1]
+        let localDateDay = getLocalDateDay()
+        day = parseInt(data2[localDateDay][0])
+        window.dailypoke = data2[localDateDay][1]
         let lang = getCookie('lang', false)
         setLanguage(lang, true)
       });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -24,3 +24,9 @@ export function setCookie(cname, cvalue, exdays, daily, streak=false) {
     let expires = "expires=" + d.toUTCString();
     document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/" + ";samesite=strict";
 }
+
+export function getLocalDateDay() {
+    let date = new Date()
+    let localOffsetMilliseconds = date.getTimezoneOffset() * 60000
+    return new Date(date.getTime() - localOffsetMilliseconds).toISOString().split("T")[0]
+}


### PR DESCRIPTION
### What
My timezone is GMT-3 and I noticed that when I played the Daily Squirdle after 9PM the secret pokémon of that day would be the same as the next day. This means that I can get two points for my streak for the same pokémon.

### Why
The code that formats the local date in `daily.html` uses the function `toISOString()` in the process to get the date in the yyyy-MM-dd format, but this function may also change the date day. Since this day is used to determine the pokémon of the day, this would cause the unexpected behavior.
For example, let's suppose it is August 13th at 22:04 for me, when I run the command `new Date()` it returns: `Sat Aug 13 2022 22:04:04 GMT-0300 (Brasilia Standard Time)`
When the code calls the function `toISOString()` it will return: `"2022-08-14T01:04:04.158Z"`
So the chosen secret pokémon will be the one from August 14th instead of August 13th!

### How
I solved this issue by removing the timezone offset from the Date, so when the `toISOString()` is called and it applies the offset it will get the correct local day and time and it will only work as a formatting function.
With this change, in the example above, the result after this function call would be `"2022-08-13T22:04:04.158Z"`, so the selected pokémon will be the one from August 13th.