### PR TITLE
Add Cookie to store pokemon stats.

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,12 +101,31 @@
 <a id="lang_fr_lnk" href="#">🇫🇷</a> |
 <a id="lang_de_lnk" href="#">🇩🇪</a>
 <br>Issues? <a href="cacheclear.html">Clear your cache!</a>
+<button id="show_stats_btn" style="position: fixed; top: 10px; right: 20px;">Show Stats</button>
 <script type="module">
-  import {getCookie} from "./scripts/utils.js";
+  import {getCookie,setCookie} from "./scripts/utils.js";
   import {setLanguage} from "./scripts/i18n.js";
   import {handleGuess, toggleHints, newGame, copyCurrentDay, handleLoad} from "./scripts/game.js";
-
+  import {showStats} from "./scripts/renderer.js";
+  
   document.addEventListener('DOMContentLoaded', (event) => {
+    console.log("Dom content loaded..")
+    console.log(` ${document.cookie}`.split(";"));
+    let statsCookie = getCookie('Stats', false);
+
+    if (!statsCookie) {
+        let initialStats = {
+            wins: 0,
+            losses: 0,
+            guessesNo: [],
+            guesses: [],
+            averageNoGuesses: 0
+        };
+
+        let statsJSON = JSON.stringify(initialStats);
+        setCookie('Stats', statsJSON, 300, false);
+    }
+
     $.getJSON("data/pokedex.json", function (json) {
       pokedex = json
       let lang = getCookie('lang', false)
@@ -145,6 +164,9 @@
   });
   document.querySelector('#lang_de_lnk').addEventListener('click', () => {
     setLanguage('de', false)
+  });
+  document.querySelector('#show_stats_btn').addEventListener('click', () => {
+      showStats();
   });
 </script>
 

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -59,11 +59,13 @@ export function copyCurrentDay(day, names) {
 }
 
 export function handleGuess(daily) {
+  console.log("4. Inside handle guess")
   const imgs = { '1': "imgs/correct.png", '2': "imgs/up.png", '3': "imgs/down.png", '4': "imgs/wrongpos.png", '5': "imgs/wrong.png" }
   let guess_name = getRevPkmnName(document.getElementById("guess").value)
   let secret_name = getRevPkmnName(getPokemonFromId(getCookie("secret_poke", daily).replace(/"/g, '')));
   let guess = pokedex[guess_name]
-
+  console.log("5. Guess,Secret.")
+  console.log(guess,secret_name)
   if (guess == null) {
     document.getElementById("error").style.display = "block";
     return
@@ -92,15 +94,18 @@ export function handleGuess(daily) {
   guesses = guesses == "" ? [] : JSON.parse(guesses)
 
   guesses.push(guess_info)
-
+  console.log(guesses)
+  console.log(`Total Guesses: ${guesses.length}`)
+  
   if(guess_name == secret_name & daily){
     let streak = getCookie("streak", false)
     streak = streak == ""? 1 : parseInt(streak)+1
     setCookie("streak", streak, 300, false, true)
   }
 
-  setCookie("guessesv2", JSON.stringify(guesses), 100, daily)
+  setCookie("guessesv2", JSON.stringify(guesses), 100, daily);
   showState(daily)
+  console.log(`2. ${document.cookie}.split(";")`)
 }
 
 export function toggleHints(daily) {

--- a/scripts/renderer.js
+++ b/scripts/renderer.js
@@ -152,6 +152,13 @@ export function showState(daily) {
     document.getElementById("attempts").innerHTML = attempts - guesses.length
 }
 
+export function showStats() {
+    console.log("Show Stats button clicked");
+    // todo : add stats here.
+    //  a histogram of stats with y values as no. of guesses. x with pokemon
+    // (spike chartjs lib)
+}
+
 function createElement(initObj) {
     let element = document.createElement(initObj.Tag);
     for (let prop in initObj) {

--- a/scripts/renderer.js
+++ b/scripts/renderer.js
@@ -102,6 +102,31 @@ export function showState(daily) {
             let title = getTitle(streak)
             document.getElementById("streak").innerHTML = "You've guessed <b>"+streak+" Pokémon</b> in a row!<br><b>Title: </b>"+title
         }
+        else{
+            // update wining stats for normal games
+            let statsCookie = getCookie('Stats', false);
+            let statsObject = statsCookie ? JSON.parse(statsCookie) : {};
+
+            statsObject.wins += 1;
+
+            // guesses graph
+            const MAX_ELEMENTS = 7;
+
+            if (statsObject.guesses.length >= MAX_ELEMENTS) {
+                statsObject.guesses.shift();
+                statsObject.guessesNo.shift();
+            }
+            statsObject.guesses.push(secret_name);
+            statsObject.guessesNo.push(guesses.length);
+            
+            // average guesses
+            let sum = statsObject.guessesNo.reduce((acc, guessValue) => acc + guessValue, 0);
+            statsObject.averageNoGuesses = sum/statsObject.guessesNo.length
+
+            let updatedStats = JSON.stringify(statsObject);
+
+            setCookie('Stats', updatedStats, 300, false);
+        }
     }
     else if (guesses.length == attempts) {
         document.getElementById("secretpoke").innerHTML = secret_name
@@ -111,6 +136,17 @@ export function showState(daily) {
         if (daily) {
             setCookie("streak", 0, 300, false)
             document.getElementById("streak").innerHTML = "Streak Reset!<br><b>Title:</b> Novice Trainer"
+        }
+        else{
+            // update losses for normal games
+            let statsCookie = getCookie('Stats', false);
+            let statsObject = statsCookie ? JSON.parse(statsCookie) : {};
+
+            statsObject.losses += 1
+            console.log(guesses);
+
+            let updatedStats = JSON.stringify(statsObject);
+            setCookie('Stats', updatedStats, 300, false);
         }
     }
     document.getElementById("attempts").innerHTML = attempts - guesses.length


### PR DESCRIPTION
This PR adds cookie to store non daily games user statistics.

Here is the sample look of cookies after 4 games .
`min_gene=1; max_gene=9; t_attempts=8; lang=; hintsenabled=0; secret_poke=1127; guessesv2=[{"hints":["imgs/up.png","imgs/wrong.png","imgs/wrong.png","imgs/up.png","imgs/up.png"],"name":892,"info":"<b>Gen:</b> 7<br><b>Type 1:</b> Poison<br><b>Type 2:</b> Fire<br><b>Height:</b> 1.2<br><b>Weight:</b> 22.2","mosaic":"25522"},{"hints":["imgs/correct.png","imgs/correct.png","imgs/correct.png","imgs/correct.png","imgs/correct.png"],"name":1127,"info":"<b>Gen:</b> 9<br><b>Type 1:</b> Electric<br><b>Type 2:</b> Ground<br><b>Height:</b> 2.3<br><b>Weight:</b> 60","mosaic":"11111"}]; Stats={"wins":4,"losses":0,"guessesNo":[2,2,3,2],"guesses":["Chi-Yu","Sunflora","Naclstack","Sandy Shocks"],"averageNoGuesses":2.25}.split(";")`


Have added skeleton for displaying the user stats (not a typical UI working guy so this might take time :/ )
Please provide comments and improvizations !!
@CC007 @Fireblend 